### PR TITLE
生年月日を加味した相性占い機能の実装 #1

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,49 @@
+// 占いの設定ファイル
+
+// 干支の配列
+export const zodiacSigns = ["子", "丑", "寅", "卯", "辰", "巳", "午", "未", "申", "酉", "戌", "亥"];
+
+// 星座の配列と日付範囲
+export const constellations = [
+    { name: "山羊座", startMonth: 12, startDay: 22, endMonth: 1, endDay: 19 },
+    { name: "水瓶座", startMonth: 1, startDay: 20, endMonth: 2, endDay: 18 },
+    { name: "魚座", startMonth: 2, startDay: 19, endMonth: 3, endDay: 20 },
+    { name: "牡羊座", startMonth: 3, startDay: 21, endMonth: 4, endDay: 19 },
+    { name: "牡牛座", startMonth: 4, startDay: 20, endMonth: 5, endDay: 20 },
+    { name: "双子座", startMonth: 5, startDay: 21, endMonth: 6, endDay: 21 },
+    { name: "蟹座", startMonth: 6, startDay: 22, endMonth: 7, endDay: 22 },
+    { name: "獅子座", startMonth: 7, startDay: 23, endMonth: 8, endDay: 22 },
+    { name: "乙女座", startMonth: 8, startDay: 23, endMonth: 9, endDay: 22 },
+    { name: "天秤座", startMonth: 9, startDay: 23, endMonth: 10, endDay: 23 },
+    { name: "蠍座", startMonth: 10, startDay: 24, endMonth: 11, endDay: 22 },
+    { name: "射手座", startMonth: 11, startDay: 23, endMonth: 12, endDay: 21 }
+];
+
+// 星座の元素マッピング
+export const elementMap = {
+    "牡羊座": "火", "獅子座": "火", "射手座": "火",
+    "牡牛座": "地", "乙女座": "地", "山羊座": "地",
+    "双子座": "風", "天秤座": "風", "水瓶座": "風",
+    "蟹座": "水", "蠍座": "水", "魚座": "水"
+};
+
+// 相性の良い元素の組み合わせ
+export const compatibleElements = {
+    "火": "風", "風": "火",
+    "地": "水", "水": "地"
+};
+
+// メッセージの設定
+export const messages = {
+    excellent: name => `運命的な出会いかもしれません！${name}%という素晴らしい相性です。`,
+    good: name => `${name}%の相性で、とても良い関係を築けそうです。`,
+    normal: name => `${name}%の相性です。時間をかけて理解を深められそうです。`,
+    challenging: name => `${name}%の相性です。違いを活かして新しい発見があるかもしれません！`
+};
+
+// 相性の重み付け設定
+export const weights = {
+    name: 0.3,
+    zodiac: 0.35,
+    constellation: 0.35
+};

--- a/index.html
+++ b/index.html
@@ -10,20 +10,82 @@
     <div class="container">
         <h1>♥ 相性占い ♥</h1>
         <div class="input-area">
-            <div class="input-group">
-                <label for="name1">あなたの名前：</label>
-                <input type="text" id="name1" placeholder="例：田中太郎" required>
+            <div class="person-info">
+                <h2>あなたの情報</h2>
+                <div class="input-group">
+                    <label for="name1">名前：</label>
+                    <input type="text" id="name1" placeholder="例：田中太郎" required>
+                </div>
+                <div class="input-group">
+                    <label>生年月日：</label>
+                    <div class="date-inputs">
+                        <select id="year1" required></select>
+                        <label>年</label>
+                        <select id="month1" required></select>
+                        <label>月</label>
+                        <select id="day1" required></select>
+                        <label>日</label>
+                    </div>
+                </div>
             </div>
-            <div class="input-group">
-                <label for="name2">相手の名前：</label>
-                <input type="text" id="name2" placeholder="例：山田花子" required>
+
+            <div class="person-info">
+                <h2>相手の情報</h2>
+                <div class="input-group">
+                    <label for="name2">名前：</label>
+                    <input type="text" id="name2" placeholder="例：山田花子" required>
+                </div>
+                <div class="input-group">
+                    <label>生年月日：</label>
+                    <div class="date-inputs">
+                        <select id="year2" required></select>
+                        <label>年</label>
+                        <select id="month2" required></select>
+                        <label>月</label>
+                        <select id="day2" required></select>
+                        <label>日</label>
+                    </div>
+                </div>
             </div>
+
             <button onclick="calculateCompatibility()">占う！</button>
         </div>
+
         <div id="result" class="hidden">
             <div class="result-text"></div>
-            <div class="compatibility-bar">
-                <div class="bar-fill"></div>
+            <div class="compatibility-details">
+                <div class="detail-item">
+                    <h3>総合相性</h3>
+                    <div class="compatibility-bar">
+                        <div class="bar-fill total"></div>
+                        <span class="percentage"></span>
+                    </div>
+                </div>
+                <div class="detail-item">
+                    <h3>名前の相性</h3>
+                    <div class="compatibility-bar">
+                        <div class="bar-fill name"></div>
+                        <span class="percentage"></span>
+                    </div>
+                </div>
+                <div class="detail-item">
+                    <h3>干支の相性</h3>
+                    <div class="compatibility-bar">
+                        <div class="bar-fill zodiac"></div>
+                        <span class="percentage"></span>
+                    </div>
+                </div>
+                <div class="detail-item">
+                    <h3>星座の相性</h3>
+                    <div class="compatibility-bar">
+                        <div class="bar-fill constellation"></div>
+                        <span class="percentage"></span>
+                    </div>
+                </div>
+            </div>
+            <div class="detail-messages">
+                <div class="zodiac-message"></div>
+                <div class="constellation-message"></div>
             </div>
             <div class="message"></div>
         </div>

--- a/index.html
+++ b/index.html
@@ -3,81 +3,99 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="名前と生年月日から相性を占うアプリ - お二人の相性を様々な角度から分析します">
+    <meta name="theme-color" content="#ff4081">
     <title>相性占い</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div class="container">
         <h1>♥ 相性占い ♥</h1>
-        <div class="input-area">
-            <div class="person-info">
-                <h2>あなたの情報</h2>
-                <div class="input-group">
-                    <label for="name1">名前：</label>
-                    <input type="text" id="name1" placeholder="例：田中太郎" required>
-                </div>
-                <div class="input-group">
-                    <label>生年月日：</label>
-                    <div class="date-inputs">
-                        <select id="year1" required></select>
-                        <label>年</label>
-                        <select id="month1" required></select>
-                        <label>月</label>
-                        <select id="day1" required></select>
-                        <label>日</label>
+        <form id="compatibilityForm" onsubmit="handleSubmit(event)">
+            <div class="input-area">
+                <div class="person-info" role="group" aria-labelledby="person1-heading">
+                    <h2 id="person1-heading">あなたの情報</h2>
+                    <div class="input-group">
+                        <label for="name1">名前：</label>
+                        <input type="text" id="name1" placeholder="例：田中太郎" required
+                               aria-required="true">
+                    </div>
+                    <div class="input-group">
+                        <label id="birth1-label">生年月日：</label>
+                        <div class="date-inputs" role="group" aria-labelledby="birth1-label">
+                            <select id="year1" required aria-label="年">
+                            </select>
+                            <label for="year1">年</label>
+                            <select id="month1" required aria-label="月">
+                            </select>
+                            <label for="month1">月</label>
+                            <select id="day1" required aria-label="日">
+                            </select>
+                            <label for="day1">日</label>
+                        </div>
                     </div>
                 </div>
-            </div>
 
-            <div class="person-info">
-                <h2>相手の情報</h2>
-                <div class="input-group">
-                    <label for="name2">名前：</label>
-                    <input type="text" id="name2" placeholder="例：山田花子" required>
-                </div>
-                <div class="input-group">
-                    <label>生年月日：</label>
-                    <div class="date-inputs">
-                        <select id="year2" required></select>
-                        <label>年</label>
-                        <select id="month2" required></select>
-                        <label>月</label>
-                        <select id="day2" required></select>
-                        <label>日</label>
+                <div class="person-info" role="group" aria-labelledby="person2-heading">
+                    <h2 id="person2-heading">相手の情報</h2>
+                    <div class="input-group">
+                        <label for="name2">名前：</label>
+                        <input type="text" id="name2" placeholder="例：山田花子" required
+                               aria-required="true">
+                    </div>
+                    <div class="input-group">
+                        <label id="birth2-label">生年月日：</label>
+                        <div class="date-inputs" role="group" aria-labelledby="birth2-label">
+                            <select id="year2" required aria-label="年">
+                            </select>
+                            <label for="year2">年</label>
+                            <select id="month2" required aria-label="月">
+                            </select>
+                            <label for="month2">月</label>
+                            <select id="day2" required aria-label="日">
+                            </select>
+                            <label for="day2">日</label>
+                        </div>
                     </div>
                 </div>
+
+                <div id="errorMessages" class="error-messages" role="alert" aria-live="polite"></div>
+                <div id="loading" class="loading hidden" role="status" aria-live="polite">
+                    <span class="spinner" aria-hidden="true"></span>
+                    <span>計算中...</span>
+                </div>
+
+                <button type="submit">占う！</button>
             </div>
+        </form>
 
-            <button onclick="calculateCompatibility()">占う！</button>
-        </div>
-
-        <div id="result" class="hidden">
-            <div class="result-text"></div>
+        <div id="result" class="hidden" role="region" aria-live="polite">
+            <div class="result-text" aria-atomic="true"></div>
             <div class="compatibility-details">
                 <div class="detail-item">
                     <h3>総合相性</h3>
-                    <div class="compatibility-bar">
+                    <div class="compatibility-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
                         <div class="bar-fill total"></div>
                         <span class="percentage"></span>
                     </div>
                 </div>
                 <div class="detail-item">
                     <h3>名前の相性</h3>
-                    <div class="compatibility-bar">
+                    <div class="compatibility-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
                         <div class="bar-fill name"></div>
                         <span class="percentage"></span>
                     </div>
                 </div>
                 <div class="detail-item">
                     <h3>干支の相性</h3>
-                    <div class="compatibility-bar">
+                    <div class="compatibility-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
                         <div class="bar-fill zodiac"></div>
                         <span class="percentage"></span>
                     </div>
                 </div>
                 <div class="detail-item">
                     <h3>星座の相性</h3>
-                    <div class="compatibility-bar">
+                    <div class="compatibility-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
                         <div class="bar-fill constellation"></div>
                         <span class="percentage"></span>
                     </div>
@@ -90,6 +108,6 @@
             <div class="message"></div>
         </div>
     </div>
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,26 +1,57 @@
-// 干支の配列
-const zodiacSigns = ["子", "丑", "寅", "卯", "辰", "巳", "午", "未", "申", "酉", "戌", "亥"];
+import {
+    zodiacSigns,
+    constellations,
+    elementMap,
+    compatibleElements,
+    messages,
+    weights
+} from './config.js';
 
-// 星座の配列と日付範囲
-const constellations = [
-    { name: "山羊座", startMonth: 12, startDay: 22, endMonth: 1, endDay: 19 },
-    { name: "水瓶座", startMonth: 1, startDay: 20, endMonth: 2, endDay: 18 },
-    { name: "魚座", startMonth: 2, startDay: 19, endMonth: 3, endDay: 20 },
-    { name: "牡羊座", startMonth: 3, startDay: 21, endMonth: 4, endDay: 19 },
-    { name: "牡牛座", startMonth: 4, startDay: 20, endMonth: 5, endDay: 20 },
-    { name: "双子座", startMonth: 5, startDay: 21, endMonth: 6, endDay: 21 },
-    { name: "蟹座", startMonth: 6, startDay: 22, endMonth: 7, endDay: 22 },
-    { name: "獅子座", startMonth: 7, startDay: 23, endMonth: 8, endDay: 22 },
-    { name: "乙女座", startMonth: 8, startDay: 23, endMonth: 9, endDay: 22 },
-    { name: "天秤座", startMonth: 9, startDay: 23, endMonth: 10, endDay: 23 },
-    { name: "蠍座", startMonth: 10, startDay: 24, endMonth: 11, endDay: 22 },
-    { name: "射手座", startMonth: 11, startDay: 23, endMonth: 12, endDay: 21 }
-];
+// フォーム送信ハンドラ
+function handleSubmit(event) {
+    event.preventDefault();
+    clearErrors();
+    showLoading();
+
+    try {
+        calculateCompatibility();
+    } catch (error) {
+        console.error('相性計算中にエラーが発生しました:', error);
+        showError('計算中にエラーが発生しました。入力を確認してください。');
+    } finally {
+        hideLoading();
+    }
+}
+
+// エラー表示関連の関数
+function showError(message) {
+    const errorDiv = document.getElementById('errorMessages');
+    errorDiv.textContent = message;
+    errorDiv.classList.add('visible');
+}
+
+function clearErrors() {
+    const errorDiv = document.getElementById('errorMessages');
+    errorDiv.textContent = '';
+    errorDiv.classList.remove('visible');
+}
+
+// ローディング表示の制御
+function showLoading() {
+    document.getElementById('loading').classList.remove('hidden');
+}
+
+function hideLoading() {
+    document.getElementById('loading').classList.add('hidden');
+}
 
 // ページ読み込み時に実行
 document.addEventListener('DOMContentLoaded', () => {
     initDateSelects('year1', 'month1', 'day1');
     initDateSelects('year2', 'month2', 'day2');
+    
+    // フォームのイベントリスナーを設定
+    document.getElementById('compatibilityForm').addEventListener('submit', handleSubmit);
 });
 
 // 年月日のセレクトボックスを初期化
@@ -29,220 +60,240 @@ function initDateSelects(yearId, monthId, dayId) {
     const monthSelect = document.getElementById(monthId);
     const daySelect = document.getElementById(dayId);
     
-    // 年の選択肢を設定（1920年から現在まで）
-    const currentYear = new Date().getFullYear();
-    for (let year = currentYear; year >= 1920; year--) {
-        const option = document.createElement('option');
-        option.value = year;
-        option.textContent = year;
-        yearSelect.appendChild(option);
-    }
-    
-    // 月の選択肢を設定
-    for (let month = 1; month <= 12; month++) {
-        const option = document.createElement('option');
-        option.value = month;
-        option.textContent = month;
-        monthSelect.appendChild(option);
-    }
-    
-    // 日付の更新関数
-    function updateDays() {
-        const year = parseInt(yearSelect.value);
-        const month = parseInt(monthSelect.value);
-        const daysInMonth = new Date(year, month, 0).getDate();
-        
-        // 現在の日付を保持
-        const currentDay = daySelect.value;
-        
-        daySelect.innerHTML = '';
-        for (let day = 1; day <= daysInMonth; day++) {
+    try {
+        // 年の選択肢を設定（1920年から現在まで）
+        const currentYear = new Date().getFullYear();
+        for (let year = currentYear; year >= 1920; year--) {
             const option = document.createElement('option');
-            option.value = day;
-            option.textContent = day;
-            daySelect.appendChild(option);
+            option.value = year;
+            option.textContent = year;
+            yearSelect.appendChild(option);
         }
         
-        // 可能であれば前の日付を復元
-        if (currentDay && currentDay <= daysInMonth) {
-            daySelect.value = currentDay;
+        // 月の選択肢を設定
+        for (let month = 1; month <= 12; month++) {
+            const option = document.createElement('option');
+            option.value = month;
+            option.textContent = month;
+            monthSelect.appendChild(option);
         }
+        
+        // 日付の更新関数
+        function updateDays() {
+            const year = parseInt(yearSelect.value);
+            const month = parseInt(monthSelect.value);
+            const daysInMonth = new Date(year, month, 0).getDate();
+            
+            // 現在の日付を保持
+            const currentDay = daySelect.value;
+            
+            daySelect.innerHTML = '';
+            for (let day = 1; day <= daysInMonth; day++) {
+                const option = document.createElement('option');
+                option.value = day;
+                option.textContent = day;
+                daySelect.appendChild(option);
+            }
+            
+            // 可能であれば前の日付を復元
+            if (currentDay && currentDay <= daysInMonth) {
+                daySelect.value = currentDay;
+            }
+        }
+        
+        // イベントリスナーを設定
+        yearSelect.addEventListener('change', updateDays);
+        monthSelect.addEventListener('change', updateDays);
+        
+        // デフォルト値を設定
+        yearSelect.value = currentYear - 25;
+        monthSelect.value = 1;
+        updateDays();
+        daySelect.value = 1;
+    } catch (error) {
+        console.error('日付セレクトボックスの初期化中にエラーが発生しました:', error);
+        showError('日付の設定中にエラーが発生しました。ページを更新してください。');
     }
-    
-    // イベントリスナーを設定
-    yearSelect.addEventListener('change', updateDays);
-    monthSelect.addEventListener('change', updateDays);
-    
-    // デフォルト値を設定
-    yearSelect.value = currentYear - 25;
-    monthSelect.value = 1;
-    updateDays();
-    daySelect.value = 1;
 }
 
 // 干支を取得
 function getZodiacSign(year) {
-    return zodiacSigns[(year - 4) % 12];
+    try {
+        return zodiacSigns[(year - 4) % 12];
+    } catch (error) {
+        throw new Error('干支の計算中にエラーが発生しました: ' + error.message);
+    }
 }
 
 // 星座を取得
 function getConstellation(month, day) {
-    for (const constellation of constellations) {
-        if (constellation.startMonth === month && day >= constellation.startDay) {
-            return constellation.name;
-        }
-        if (constellation.endMonth === month && day <= constellation.endDay) {
-            return constellation.name;
-        }
-        if (constellation.startMonth === 12 && month === 1 && day <= constellation.endDay) {
-            return constellation.name;
-        }
-        if (constellation.startMonth === 12 && month === 12 && day >= constellation.startDay) {
-            return constellation.name;
-        }
+    try {
+        return constellations.find(c => {
+            if (c.startMonth === 12 && month === 1 && day <= c.endDay) return true;
+            if (c.startMonth === 12 && month === 12 && day >= c.startDay) return true;
+            if (c.startMonth === month && day >= c.startDay) return true;
+            if (c.endMonth === month && day <= c.endDay) return true;
+            return false;
+        })?.name;
+    } catch (error) {
+        throw new Error('星座の計算中にエラーが発生しました: ' + error.message);
     }
-    return constellations.find(c => 
-        (month === c.startMonth && day >= c.startDay) || 
-        (month === c.endMonth && day <= c.endDay)
-    ).name;
 }
 
 // 干支の相性を計算
 function calculateZodiacCompatibility(zodiac1, zodiac2) {
-    const index1 = zodiacSigns.indexOf(zodiac1);
-    const index2 = zodiacSigns.indexOf(zodiac2);
-    const difference = Math.abs(index1 - index2);
-    
-    // 干支の相性ルール（単純な例）
-    if (difference === 0) return 100; // 同じ干支
-    if (difference === 6) return 30;  // 対極の干支
-    if (difference === 4 || difference === 8) return 80; // 三合
-    if (difference === 3 || difference === 9) return 60; // 四極
-    return 50; // その他
+    try {
+        const index1 = zodiacSigns.indexOf(zodiac1);
+        const index2 = zodiacSigns.indexOf(zodiac2);
+        const difference = Math.abs(index1 - index2);
+        
+        if (difference === 0) return 100; // 同じ干支
+        if (difference === 6) return 30;  // 対極の干支
+        if (difference === 4 || difference === 8) return 80; // 三合
+        if (difference === 3 || difference === 9) return 60; // 四極
+        return 50; // その他
+    } catch (error) {
+        throw new Error('干支の相性計算中にエラーが発生しました: ' + error.message);
+    }
 }
 
 // 星座の相性を計算
 function calculateConstellationCompatibility(const1, const2) {
-    // 星座の相性ルール（実際にはもっと複雑なルールを実装可能）
-    const elementMap = {
-        "牡羊座": "火", "獅子座": "火", "射手座": "火",
-        "牡牛座": "地", "乙女座": "地", "山羊座": "地",
-        "双子座": "風", "天秤座": "風", "水瓶座": "風",
-        "蟹座": "水", "蠍座": "水", "魚座": "水"
-    };
-    
-    const element1 = elementMap[const1];
-    const element2 = elementMap[const2];
-    
-    if (const1 === const2) return 90; // 同じ星座
-    if (element1 === element2) return 80; // 同じ元素
-    
-    // 相性の良い元素の組み合わせ
-    const goodPairs = {
-        "火": "風", "風": "火",
-        "地": "水", "水": "地"
-    };
-    
-    if (goodPairs[element1] === element2) return 70;
-    return 50; // その他の組み合わせ
-}
-
-// 相性を計算する関数
-function calculateCompatibility() {
-    // 入力値を取得
-    const name1 = document.getElementById('name1').value;
-    const name2 = document.getElementById('name2').value;
-    const year1 = parseInt(document.getElementById('year1').value);
-    const month1 = parseInt(document.getElementById('month1').value);
-    const day1 = parseInt(document.getElementById('day1').value);
-    const year2 = parseInt(document.getElementById('year2').value);
-    const month2 = parseInt(document.getElementById('month2').value);
-    const day2 = parseInt(document.getElementById('day2').value);
-
-    if (!name1 || !name2 || !year1 || !year2 || !month1 || !month2 || !day1 || !day2) {
-        alert('すべての項目を入力してください！');
-        return;
+    try {
+        if (const1 === const2) return 90; // 同じ星座
+        
+        const element1 = elementMap[const1];
+        const element2 = elementMap[const2];
+        
+        if (element1 === element2) return 80; // 同じ元素
+        if (compatibleElements[element1] === element2) return 70; // 相性の良い元素
+        return 50; // その他
+    } catch (error) {
+        throw new Error('星座の相性計算中にエラーが発生しました: ' + error.message);
     }
-
-    // 各種相性を計算
-    const nameCompatibility = calculateNameCompatibility(name1, name2);
-    const zodiac1 = getZodiacSign(year1);
-    const zodiac2 = getZodiacSign(year2);
-    const zodiacCompatibility = calculateZodiacCompatibility(zodiac1, zodiac2);
-    const constellation1 = getConstellation(month1, day1);
-    const constellation2 = getConstellation(month2, day2);
-    const constellationCompatibility = calculateConstellationCompatibility(constellation1, constellation2);
-
-    // 総合相性を計算（重み付け）
-    const totalCompatibility = Math.round(
-        (nameCompatibility * 0.3) + 
-        (zodiacCompatibility * 0.35) + 
-        (constellationCompatibility * 0.35)
-    );
-
-    // 結果を表示
-    displayResults({
-        total: totalCompatibility,
-        name: nameCompatibility,
-        zodiac: zodiacCompatibility,
-        constellation: constellationCompatibility,
-        zodiac1, zodiac2,
-        constellation1, constellation2,
-        name1, name2
-    });
 }
 
 // 名前の相性を計算
 function calculateNameCompatibility(name1, name2) {
-    const combined = name1 + name2;
-    let hash = 0;
-    for (let i = 0; i < combined.length; i++) {
-        hash = ((hash << 5) - hash) + combined.charCodeAt(i);
-        hash = hash & hash;
+    try {
+        const combined = name1 + name2;
+        let hash = 0;
+        for (let i = 0; i < combined.length; i++) {
+            hash = ((hash << 5) - hash) + combined.charCodeAt(i);
+            hash = hash & hash;
+        }
+        return Math.abs(hash % 101);
+    } catch (error) {
+        throw new Error('名前の相性計算中にエラーが発生しました: ' + error.message);
     }
-    return Math.abs(hash % 101);
+}
+
+// 入力値の取得とバリデーション
+function getValidatedInputs() {
+    const inputs = {
+        name1: document.getElementById('name1').value,
+        name2: document.getElementById('name2').value,
+        year1: parseInt(document.getElementById('year1').value),
+        month1: parseInt(document.getElementById('month1').value),
+        day1: parseInt(document.getElementById('day1').value),
+        year2: parseInt(document.getElementById('year2').value),
+        month2: parseInt(document.getElementById('month2').value),
+        day2: parseInt(document.getElementById('day2').value)
+    };
+
+    if (!Object.values(inputs).every(Boolean)) {
+        throw new Error('すべての項目を入力してください');
+    }
+
+    return inputs;
+}
+
+// 相性を計算する関数
+function calculateCompatibility() {
+    try {
+        const inputs = getValidatedInputs();
+        
+        // 各種相性を計算
+        const nameCompatibility = calculateNameCompatibility(inputs.name1, inputs.name2);
+        const zodiac1 = getZodiacSign(inputs.year1);
+        const zodiac2 = getZodiacSign(inputs.year2);
+        const zodiacCompatibility = calculateZodiacCompatibility(zodiac1, zodiac2);
+        const constellation1 = getConstellation(inputs.month1, inputs.day1);
+        const constellation2 = getConstellation(inputs.month2, inputs.day2);
+        const constellationCompatibility = calculateConstellationCompatibility(constellation1, constellation2);
+
+        // 総合相性を計算（重み付け）
+        const totalCompatibility = Math.round(
+            (nameCompatibility * weights.name) +
+            (zodiacCompatibility * weights.zodiac) +
+            (constellationCompatibility * weights.constellation)
+        );
+
+        displayResults({
+            total: totalCompatibility,
+            name: nameCompatibility,
+            zodiac: zodiacCompatibility,
+            constellation: constellationCompatibility,
+            zodiac1,
+            zodiac2,
+            constellation1,
+            constellation2,
+            name1: inputs.name1,
+            name2: inputs.name2
+        });
+
+    } catch (error) {
+        throw new Error('相性計算中にエラーが発生しました: ' + error.message);
+    }
 }
 
 // 結果を表示
 function displayResults(results) {
-    const resultDiv = document.getElementById('result');
-    resultDiv.classList.remove('hidden');
+    try {
+        const resultDiv = document.getElementById('result');
+        resultDiv.classList.remove('hidden', 'excellent', 'good', 'normal', 'challenging');
 
-    // 総合相性
-    document.querySelector('.bar-fill.total').style.width = `${results.total}%`;
-    document.querySelector('.detail-item:nth-child(1) .percentage').textContent = `${results.total}%`;
+        // プログレスバーとパーセンテージを更新
+        updateProgressBar('.total', results.total);
+        updateProgressBar('.name', results.name);
+        updateProgressBar('.zodiac', results.zodiac);
+        updateProgressBar('.constellation', results.constellation);
 
-    // 名前の相性
-    document.querySelector('.bar-fill.name').style.width = `${results.name}%`;
-    document.querySelector('.detail-item:nth-child(2) .percentage').textContent = `${results.name}%`;
+        // メッセージを更新
+        document.querySelector('.zodiac-message').textContent =
+            `${results.name1}さん(${results.zodiac1})と${results.name2}さん(${results.zodiac2})の干支の相性は${results.zodiac}%です。`;
+        
+        document.querySelector('.constellation-message').textContent =
+            `${results.name1}さん(${results.constellation1})と${results.name2}さん(${results.constellation2})の星座の相性は${results.constellation}%です。`;
 
-    // 干支の相性
-    document.querySelector('.bar-fill.zodiac').style.width = `${results.zodiac}%`;
-    document.querySelector('.detail-item:nth-child(3) .percentage').textContent = `${results.zodiac}%`;
-    document.querySelector('.zodiac-message').textContent = 
-        `${results.name1}さん(${results.zodiac1})と${results.name2}さん(${results.zodiac2})の干支の相性は${results.zodiac}%です。`;
+        // 総合結果のメッセージを設定
+        const messageKey = results.total >= 80 ? 'excellent' :
+                          results.total >= 60 ? 'good' :
+                          results.total >= 40 ? 'normal' :
+                          'challenging';
 
-    // 星座の相性
-    document.querySelector('.bar-fill.constellation').style.width = `${results.constellation}%`;
-    document.querySelector('.detail-item:nth-child(4) .percentage').textContent = `${results.constellation}%`;
-    document.querySelector('.constellation-message').textContent = 
-        `${results.name1}さん(${results.constellation1})と${results.name2}さん(${results.constellation2})の星座の相性は${results.constellation}%です。`;
+        resultDiv.classList.add(messageKey);
+        document.querySelector('.message').textContent = messages[messageKey](results.total);
 
-    // 総合メッセージ
-    const message = document.querySelector('.message');
-    let totalMessage;
-    if (results.total >= 80) {
-        totalMessage = `運命的な出会いかもしれません！${results.total}%という素晴らしい相性です。`;
-        resultDiv.className = 'excellent';
-    } else if (results.total >= 60) {
-        totalMessage = `${results.total}%の相性で、とても良い関係を築けそうです。`;
-        resultDiv.className = 'good';
-    } else if (results.total >= 40) {
-        totalMessage = `${results.total}%の相性です。時間をかけて理解を深められそうです。`;
-        resultDiv.className = 'normal';
-    } else {
-        totalMessage = `${results.total}%の相性です。違いを活かして新しい発見があるかもしれません！`;
-        resultDiv.className = 'challenging';
+        // 結果を表示
+        resultDiv.classList.remove('hidden');
+        resultDiv.scrollIntoView({ behavior: 'smooth' });
+
+    } catch (error) {
+        throw new Error('結果の表示中にエラーが発生しました: ' + error.message);
     }
-    message.textContent = totalMessage;
 }
+
+// プログレスバーの更新
+function updateProgressBar(selector, value) {
+    const bar = document.querySelector(`.bar-fill${selector}`);
+    const percentage = bar.parentElement.querySelector('.percentage');
+    const progressBar = bar.parentElement;
+
+    bar.style.width = `${value}%`;
+    percentage.textContent = `${value}%`;
+    progressBar.setAttribute('aria-valuenow', value);
+}
+
+// グローバルスコープにエクスポート
+window.handleSubmit = handleSubmit;

--- a/script.js
+++ b/script.js
@@ -1,53 +1,248 @@
+// 干支の配列
+const zodiacSigns = ["子", "丑", "寅", "卯", "辰", "巳", "午", "未", "申", "酉", "戌", "亥"];
+
+// 星座の配列と日付範囲
+const constellations = [
+    { name: "山羊座", startMonth: 12, startDay: 22, endMonth: 1, endDay: 19 },
+    { name: "水瓶座", startMonth: 1, startDay: 20, endMonth: 2, endDay: 18 },
+    { name: "魚座", startMonth: 2, startDay: 19, endMonth: 3, endDay: 20 },
+    { name: "牡羊座", startMonth: 3, startDay: 21, endMonth: 4, endDay: 19 },
+    { name: "牡牛座", startMonth: 4, startDay: 20, endMonth: 5, endDay: 20 },
+    { name: "双子座", startMonth: 5, startDay: 21, endMonth: 6, endDay: 21 },
+    { name: "蟹座", startMonth: 6, startDay: 22, endMonth: 7, endDay: 22 },
+    { name: "獅子座", startMonth: 7, startDay: 23, endMonth: 8, endDay: 22 },
+    { name: "乙女座", startMonth: 8, startDay: 23, endMonth: 9, endDay: 22 },
+    { name: "天秤座", startMonth: 9, startDay: 23, endMonth: 10, endDay: 23 },
+    { name: "蠍座", startMonth: 10, startDay: 24, endMonth: 11, endDay: 22 },
+    { name: "射手座", startMonth: 11, startDay: 23, endMonth: 12, endDay: 21 }
+];
+
+// ページ読み込み時に実行
+document.addEventListener('DOMContentLoaded', () => {
+    initDateSelects('year1', 'month1', 'day1');
+    initDateSelects('year2', 'month2', 'day2');
+});
+
+// 年月日のセレクトボックスを初期化
+function initDateSelects(yearId, monthId, dayId) {
+    const yearSelect = document.getElementById(yearId);
+    const monthSelect = document.getElementById(monthId);
+    const daySelect = document.getElementById(dayId);
+    
+    // 年の選択肢を設定（1920年から現在まで）
+    const currentYear = new Date().getFullYear();
+    for (let year = currentYear; year >= 1920; year--) {
+        const option = document.createElement('option');
+        option.value = year;
+        option.textContent = year;
+        yearSelect.appendChild(option);
+    }
+    
+    // 月の選択肢を設定
+    for (let month = 1; month <= 12; month++) {
+        const option = document.createElement('option');
+        option.value = month;
+        option.textContent = month;
+        monthSelect.appendChild(option);
+    }
+    
+    // 日付の更新関数
+    function updateDays() {
+        const year = parseInt(yearSelect.value);
+        const month = parseInt(monthSelect.value);
+        const daysInMonth = new Date(year, month, 0).getDate();
+        
+        // 現在の日付を保持
+        const currentDay = daySelect.value;
+        
+        daySelect.innerHTML = '';
+        for (let day = 1; day <= daysInMonth; day++) {
+            const option = document.createElement('option');
+            option.value = day;
+            option.textContent = day;
+            daySelect.appendChild(option);
+        }
+        
+        // 可能であれば前の日付を復元
+        if (currentDay && currentDay <= daysInMonth) {
+            daySelect.value = currentDay;
+        }
+    }
+    
+    // イベントリスナーを設定
+    yearSelect.addEventListener('change', updateDays);
+    monthSelect.addEventListener('change', updateDays);
+    
+    // デフォルト値を設定
+    yearSelect.value = currentYear - 25;
+    monthSelect.value = 1;
+    updateDays();
+    daySelect.value = 1;
+}
+
+// 干支を取得
+function getZodiacSign(year) {
+    return zodiacSigns[(year - 4) % 12];
+}
+
+// 星座を取得
+function getConstellation(month, day) {
+    for (const constellation of constellations) {
+        if (constellation.startMonth === month && day >= constellation.startDay) {
+            return constellation.name;
+        }
+        if (constellation.endMonth === month && day <= constellation.endDay) {
+            return constellation.name;
+        }
+        if (constellation.startMonth === 12 && month === 1 && day <= constellation.endDay) {
+            return constellation.name;
+        }
+        if (constellation.startMonth === 12 && month === 12 && day >= constellation.startDay) {
+            return constellation.name;
+        }
+    }
+    return constellations.find(c => 
+        (month === c.startMonth && day >= c.startDay) || 
+        (month === c.endMonth && day <= c.endDay)
+    ).name;
+}
+
+// 干支の相性を計算
+function calculateZodiacCompatibility(zodiac1, zodiac2) {
+    const index1 = zodiacSigns.indexOf(zodiac1);
+    const index2 = zodiacSigns.indexOf(zodiac2);
+    const difference = Math.abs(index1 - index2);
+    
+    // 干支の相性ルール（単純な例）
+    if (difference === 0) return 100; // 同じ干支
+    if (difference === 6) return 30;  // 対極の干支
+    if (difference === 4 || difference === 8) return 80; // 三合
+    if (difference === 3 || difference === 9) return 60; // 四極
+    return 50; // その他
+}
+
+// 星座の相性を計算
+function calculateConstellationCompatibility(const1, const2) {
+    // 星座の相性ルール（実際にはもっと複雑なルールを実装可能）
+    const elementMap = {
+        "牡羊座": "火", "獅子座": "火", "射手座": "火",
+        "牡牛座": "地", "乙女座": "地", "山羊座": "地",
+        "双子座": "風", "天秤座": "風", "水瓶座": "風",
+        "蟹座": "水", "蠍座": "水", "魚座": "水"
+    };
+    
+    const element1 = elementMap[const1];
+    const element2 = elementMap[const2];
+    
+    if (const1 === const2) return 90; // 同じ星座
+    if (element1 === element2) return 80; // 同じ元素
+    
+    // 相性の良い元素の組み合わせ
+    const goodPairs = {
+        "火": "風", "風": "火",
+        "地": "水", "水": "地"
+    };
+    
+    if (goodPairs[element1] === element2) return 70;
+    return 50; // その他の組み合わせ
+}
+
+// 相性を計算する関数
 function calculateCompatibility() {
+    // 入力値を取得
     const name1 = document.getElementById('name1').value;
     const name2 = document.getElementById('name2').value;
+    const year1 = parseInt(document.getElementById('year1').value);
+    const month1 = parseInt(document.getElementById('month1').value);
+    const day1 = parseInt(document.getElementById('day1').value);
+    const year2 = parseInt(document.getElementById('year2').value);
+    const month2 = parseInt(document.getElementById('month2').value);
+    const day2 = parseInt(document.getElementById('day2').value);
 
-    if (!name1 || !name2) {
-        alert('両方の名前を入力してください！');
+    if (!name1 || !name2 || !year1 || !year2 || !month1 || !month2 || !day1 || !day2) {
+        alert('すべての項目を入力してください！');
         return;
     }
 
-    // 名前の文字列を結合してハッシュ値を生成
+    // 各種相性を計算
+    const nameCompatibility = calculateNameCompatibility(name1, name2);
+    const zodiac1 = getZodiacSign(year1);
+    const zodiac2 = getZodiacSign(year2);
+    const zodiacCompatibility = calculateZodiacCompatibility(zodiac1, zodiac2);
+    const constellation1 = getConstellation(month1, day1);
+    const constellation2 = getConstellation(month2, day2);
+    const constellationCompatibility = calculateConstellationCompatibility(constellation1, constellation2);
+
+    // 総合相性を計算（重み付け）
+    const totalCompatibility = Math.round(
+        (nameCompatibility * 0.3) + 
+        (zodiacCompatibility * 0.35) + 
+        (constellationCompatibility * 0.35)
+    );
+
+    // 結果を表示
+    displayResults({
+        total: totalCompatibility,
+        name: nameCompatibility,
+        zodiac: zodiacCompatibility,
+        constellation: constellationCompatibility,
+        zodiac1, zodiac2,
+        constellation1, constellation2,
+        name1, name2
+    });
+}
+
+// 名前の相性を計算
+function calculateNameCompatibility(name1, name2) {
     const combined = name1 + name2;
     let hash = 0;
     for (let i = 0; i < combined.length; i++) {
         hash = ((hash << 5) - hash) + combined.charCodeAt(i);
         hash = hash & hash;
     }
+    return Math.abs(hash % 101);
+}
 
-    // 0-100の範囲で相性値を生成
-    const compatibility = Math.abs(hash % 101);
-    
-    // 結果の表示を更新
+// 結果を表示
+function displayResults(results) {
     const resultDiv = document.getElementById('result');
-    const resultText = resultDiv.querySelector('.result-text');
-    const barFill = resultDiv.querySelector('.bar-fill');
-    const message = resultDiv.querySelector('.message');
+    resultDiv.classList.remove('hidden');
 
-    // アニメーション用にクラスをリセット
-    resultDiv.classList.remove('hidden', 'excellent', 'good', 'normal', 'challenging');
+    // 総合相性
+    document.querySelector('.bar-fill.total').style.width = `${results.total}%`;
+    document.querySelector('.detail-item:nth-child(1) .percentage').textContent = `${results.total}%`;
 
-    // 相性値に応じてメッセージと表示を設定
-    let messageText = '';
-    let className = '';
+    // 名前の相性
+    document.querySelector('.bar-fill.name').style.width = `${results.name}%`;
+    document.querySelector('.detail-item:nth-child(2) .percentage').textContent = `${results.name}%`;
 
-    if (compatibility >= 80) {
-        messageText = `運命的な出会いかもしれません！\n${name1}さんと${name2}さんの相性は抜群です！`;
-        className = 'excellent';
-    } else if (compatibility >= 60) {
-        messageText = `${name1}さんと${name2}さんは良い関係を築けそうです。\n互いを理解し合える素晴らしい関係になれるでしょう。`;
-        className = 'good';
-    } else if (compatibility >= 40) {
-        messageText = `${name1}さんと${name2}さんは徐々に理解を深められそうです。\n時間をかけることで、より良い関係を築けるかもしれません。`;
-        className = 'normal';
+    // 干支の相性
+    document.querySelector('.bar-fill.zodiac').style.width = `${results.zodiac}%`;
+    document.querySelector('.detail-item:nth-child(3) .percentage').textContent = `${results.zodiac}%`;
+    document.querySelector('.zodiac-message').textContent = 
+        `${results.name1}さん(${results.zodiac1})と${results.name2}さん(${results.zodiac2})の干支の相性は${results.zodiac}%です。`;
+
+    // 星座の相性
+    document.querySelector('.bar-fill.constellation').style.width = `${results.constellation}%`;
+    document.querySelector('.detail-item:nth-child(4) .percentage').textContent = `${results.constellation}%`;
+    document.querySelector('.constellation-message').textContent = 
+        `${results.name1}さん(${results.constellation1})と${results.name2}さん(${results.constellation2})の星座の相性は${results.constellation}%です。`;
+
+    // 総合メッセージ
+    const message = document.querySelector('.message');
+    let totalMessage;
+    if (results.total >= 80) {
+        totalMessage = `運命的な出会いかもしれません！${results.total}%という素晴らしい相性です。`;
+        resultDiv.className = 'excellent';
+    } else if (results.total >= 60) {
+        totalMessage = `${results.total}%の相性で、とても良い関係を築けそうです。`;
+        resultDiv.className = 'good';
+    } else if (results.total >= 40) {
+        totalMessage = `${results.total}%の相性です。時間をかけて理解を深められそうです。`;
+        resultDiv.className = 'normal';
     } else {
-        messageText = `${name1}さんと${name2}さんの関係には少し工夫が必要かもしれません。\n違いを認め合うことで、新しい発見があるかもしれません！`;
-        className = 'challenging';
+        totalMessage = `${results.total}%の相性です。違いを活かして新しい発見があるかもしれません！`;
+        resultDiv.className = 'challenging';
     }
-
-    // 結果を表示
-    resultText.textContent = `相性は${compatibility}%です！`;
-    message.textContent = messageText;
-    barFill.style.width = `${compatibility}%`;
-    resultDiv.classList.add(className);
+    message.textContent = totalMessage;
 }

--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ body {
     padding: 30px;
     border-radius: 15px;
     box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
-    max-width: 500px;
+    max-width: 800px;
     width: 100%;
 }
 
@@ -24,8 +24,27 @@ h1 {
     margin-bottom: 30px;
 }
 
+h2 {
+    color: #ff4081;
+    font-size: 1.2em;
+    margin-bottom: 15px;
+}
+
+h3 {
+    color: #666;
+    font-size: 1.1em;
+    margin: 10px 0;
+}
+
 .input-area {
     margin-bottom: 30px;
+}
+
+.person-info {
+    background-color: #fff5f8;
+    padding: 20px;
+    border-radius: 10px;
+    margin-bottom: 20px;
 }
 
 .input-group {
@@ -54,6 +73,30 @@ input:focus {
     outline: none;
 }
 
+.date-inputs {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.date-inputs select {
+    padding: 12px;
+    border: 2px solid #ffd4e5;
+    border-radius: 8px;
+    font-size: 16px;
+    transition: border-color 0.3s;
+}
+
+.date-inputs select:focus {
+    border-color: #ff4081;
+    outline: none;
+}
+
+.date-inputs label {
+    margin: 0;
+    color: #666;
+}
+
 button {
     width: 100%;
     padding: 15px;
@@ -64,6 +107,7 @@ button {
     font-size: 18px;
     cursor: pointer;
     transition: background-color 0.3s;
+    margin-top: 20px;
 }
 
 button:hover {
@@ -75,6 +119,7 @@ button:hover {
     padding: 20px;
     border-radius: 8px;
     margin-top: 30px;
+    background-color: #fff5f8;
 }
 
 #result.hidden {
@@ -88,24 +133,64 @@ button:hover {
     color: #ff4081;
 }
 
+.compatibility-details {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+    margin: 20px 0;
+}
+
+.detail-item {
+    background-color: white;
+    padding: 15px;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
 .compatibility-bar {
     background-color: #f0f0f0;
     height: 20px;
     border-radius: 10px;
-    margin: 20px 0;
+    margin: 10px 0;
     overflow: hidden;
+    position: relative;
 }
 
 .bar-fill {
     height: 100%;
     background-color: #ff4081;
     transition: width 1s ease-in-out;
+    position: relative;
+}
+
+.compatibility-bar .percentage {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #333;
+    font-weight: bold;
+    text-shadow: 1px 1px 1px rgba(255,255,255,0.5);
+}
+
+.detail-messages {
+    text-align: left;
+    margin: 20px 0;
+}
+
+.zodiac-message, .constellation-message {
+    background-color: white;
+    padding: 15px;
+    border-radius: 8px;
+    margin-bottom: 10px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
 }
 
 .message {
     font-size: 18px;
     line-height: 1.5;
     color: #666;
+    margin-top: 20px;
 }
 
 /* 結果の色分け */
@@ -113,3 +198,18 @@ button:hover {
 .good .result-text { color: #2196f3; }
 .normal .result-text { color: #4caf50; }
 .challenging .result-text { color: #ff9800; }
+
+@media (max-width: 600px) {
+    .container {
+        padding: 15px;
+    }
+
+    .date-inputs {
+        flex-wrap: wrap;
+    }
+
+    .date-inputs select {
+        flex: 1;
+        min-width: 80px;
+    }
+}

--- a/style.css
+++ b/style.css
@@ -1,125 +1,146 @@
+:root {
+    --primary-color: #ff4081;
+    --primary-light: #ffd4e5;
+    --primary-dark: #f50057;
+    --background-color: #ffe6f0;
+    --text-color: #333;
+    --text-light: #666;
+    --white: #ffffff;
+    --shadow-color: rgba(0, 0, 0, 0.1);
+    --animation-duration: 0.3s;
+    --spacing-unit: 8px;
+    --border-radius: 8px;
+}
+
 body {
     font-family: 'Arial', sans-serif;
-    background-color: #ffe6f0;
+    background-color: var(--background-color);
     margin: 0;
-    padding: 20px;
+    padding: calc(var(--spacing-unit) * 2.5);
     display: flex;
     justify-content: center;
     align-items: center;
     min-height: 100vh;
+    color: var(--text-color);
 }
 
 .container {
-    background-color: white;
-    padding: 30px;
-    border-radius: 15px;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+    background-color: var(--white);
+    padding: calc(var(--spacing-unit) * 3.75);
+    border-radius: calc(var(--spacing-unit) * 2);
+    box-shadow: 0 0 20px var(--shadow-color);
     max-width: 800px;
     width: 100%;
 }
 
 h1 {
     text-align: center;
-    color: #ff4081;
-    margin-bottom: 30px;
+    color: var(--primary-color);
+    margin-bottom: calc(var(--spacing-unit) * 3.75);
 }
 
 h2 {
-    color: #ff4081;
+    color: var(--primary-color);
     font-size: 1.2em;
-    margin-bottom: 15px;
+    margin-bottom: calc(var(--spacing-unit) * 1.875);
 }
 
 h3 {
-    color: #666;
+    color: var(--text-light);
     font-size: 1.1em;
-    margin: 10px 0;
+    margin: calc(var(--spacing-unit) * 1.25) 0;
 }
 
 .input-area {
-    margin-bottom: 30px;
+    margin-bottom: calc(var(--spacing-unit) * 3.75);
 }
 
 .person-info {
-    background-color: #fff5f8;
-    padding: 20px;
-    border-radius: 10px;
-    margin-bottom: 20px;
+    background-color: var(--primary-light);
+    padding: calc(var(--spacing-unit) * 2.5);
+    border-radius: var(--border-radius);
+    margin-bottom: calc(var(--spacing-unit) * 2.5);
 }
 
 .input-group {
-    margin-bottom: 20px;
+    margin-bottom: calc(var(--spacing-unit) * 2.5);
 }
 
 label {
     display: block;
-    margin-bottom: 8px;
-    color: #333;
+    margin-bottom: var(--spacing-unit);
+    color: var(--text-color);
     font-weight: bold;
 }
 
 input {
     width: 100%;
-    padding: 12px;
-    border: 2px solid #ffd4e5;
-    border-radius: 8px;
+    padding: calc(var(--spacing-unit) * 1.5);
+    border: 2px solid var(--primary-light);
+    border-radius: var(--border-radius);
     font-size: 16px;
-    transition: border-color 0.3s;
+    transition: border-color var(--animation-duration);
     box-sizing: border-box;
 }
 
 input:focus {
-    border-color: #ff4081;
+    border-color: var(--primary-color);
     outline: none;
 }
 
 .date-inputs {
     display: flex;
-    gap: 10px;
+    gap: var(--spacing-unit);
     align-items: center;
 }
 
 .date-inputs select {
-    padding: 12px;
-    border: 2px solid #ffd4e5;
-    border-radius: 8px;
+    padding: calc(var(--spacing-unit) * 1.5);
+    border: 2px solid var(--primary-light);
+    border-radius: var(--border-radius);
     font-size: 16px;
-    transition: border-color 0.3s;
+    transition: border-color var(--animation-duration);
 }
 
 .date-inputs select:focus {
-    border-color: #ff4081;
+    border-color: var(--primary-color);
     outline: none;
 }
 
 .date-inputs label {
     margin: 0;
-    color: #666;
+    color: var(--text-light);
 }
 
 button {
     width: 100%;
-    padding: 15px;
-    background-color: #ff4081;
-    color: white;
+    padding: calc(var(--spacing-unit) * 1.875);
+    background-color: var(--primary-color);
+    color: var(--white);
     border: none;
-    border-radius: 8px;
+    border-radius: var(--border-radius);
     font-size: 18px;
     cursor: pointer;
-    transition: background-color 0.3s;
-    margin-top: 20px;
+    transition: background-color var(--animation-duration);
+    margin-top: calc(var(--spacing-unit) * 2.5);
+    transform: translateZ(0);
 }
 
 button:hover {
-    background-color: #f50057;
+    background-color: var(--primary-dark);
+}
+
+button:focus-visible {
+    outline: 3px solid var(--primary-color);
+    outline-offset: 2px;
 }
 
 #result {
     text-align: center;
-    padding: 20px;
-    border-radius: 8px;
-    margin-top: 30px;
-    background-color: #fff5f8;
+    padding: calc(var(--spacing-unit) * 2.5);
+    border-radius: var(--border-radius);
+    margin-top: calc(var(--spacing-unit) * 3.75);
+    background-color: var(--primary-light);
 }
 
 #result.hidden {
@@ -129,38 +150,39 @@ button:hover {
 .result-text {
     font-size: 24px;
     font-weight: bold;
-    margin-bottom: 20px;
-    color: #ff4081;
+    margin-bottom: calc(var(--spacing-unit) * 2.5);
+    color: var(--primary-color);
 }
 
 .compatibility-details {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 20px;
-    margin: 20px 0;
+    gap: calc(var(--spacing-unit) * 2.5);
+    margin: calc(var(--spacing-unit) * 2.5) 0;
 }
 
 .detail-item {
-    background-color: white;
-    padding: 15px;
-    border-radius: 8px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    background-color: var(--white);
+    padding: calc(var(--spacing-unit) * 1.875);
+    border-radius: var(--border-radius);
+    box-shadow: 0 2px 5px var(--shadow-color);
 }
 
 .compatibility-bar {
     background-color: #f0f0f0;
     height: 20px;
-    border-radius: 10px;
-    margin: 10px 0;
+    border-radius: calc(var(--border-radius) * 1.25);
+    margin: var(--spacing-unit) 0;
     overflow: hidden;
     position: relative;
 }
 
 .bar-fill {
     height: 100%;
-    background-color: #ff4081;
+    background-color: var(--primary-color);
     transition: width 1s ease-in-out;
     position: relative;
+    transform: translateZ(0);
 }
 
 .compatibility-bar .percentage {
@@ -168,40 +190,88 @@ button:hover {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    color: #333;
+    color: var(--text-color);
     font-weight: bold;
     text-shadow: 1px 1px 1px rgba(255,255,255,0.5);
 }
 
 .detail-messages {
     text-align: left;
-    margin: 20px 0;
+    margin: calc(var(--spacing-unit) * 2.5) 0;
 }
 
 .zodiac-message, .constellation-message {
-    background-color: white;
-    padding: 15px;
-    border-radius: 8px;
-    margin-bottom: 10px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    background-color: var(--white);
+    padding: calc(var(--spacing-unit) * 1.875);
+    border-radius: var(--border-radius);
+    margin-bottom: var(--spacing-unit);
+    box-shadow: 0 2px 5px var(--shadow-color);
 }
 
 .message {
     font-size: 18px;
     line-height: 1.5;
-    color: #666;
-    margin-top: 20px;
+    color: var(--text-light);
+    margin-top: calc(var(--spacing-unit) * 2.5);
+}
+
+.error-messages {
+    color: #f44336;
+    margin: var(--spacing-unit) 0;
+    padding: var(--spacing-unit);
+    border-radius: var(--border-radius);
+    background-color: #ffebee;
+    display: none;
+}
+
+.error-messages.visible {
+    display: block;
+}
+
+.loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-unit);
+    margin: var(--spacing-unit) 0;
+}
+
+.loading.hidden {
+    display: none;
+}
+
+.spinner {
+    width: 20px;
+    height: 20px;
+    border: 3px solid var(--primary-light);
+    border-top-color: var(--primary-color);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 /* 結果の色分け */
-.excellent .result-text { color: #ff4081; }
+.excellent .result-text { color: var(--primary-color); }
 .good .result-text { color: #2196f3; }
 .normal .result-text { color: #4caf50; }
 .challenging .result-text { color: #ff9800; }
 
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+    }
+}
+
 @media (max-width: 600px) {
     .container {
-        padding: 15px;
+        padding: calc(var(--spacing-unit) * 1.875);
     }
 
     .date-inputs {


### PR DESCRIPTION
## 変更内容

Issue #1 で要望のあった生年月日を考慮した相性占い機能を実装しました。

### 追加された機能

1. 生年月日入力機能
   - 年月日をセレクトボックスで選択可能
   - 1920年から現在までの年を選択可能
   - 月に応じた適切な日付の選択肢を表示

2. 新しい相性計算要素
   - 干支による相性計算
   - 星座による相性計算
   - 名前の相性（既存）との重み付け計算

3. UI/UXの改善
   - 詳細な結果表示（総合・名前・干支・星座別）
   - プログレスバーによる視覚的な表示
   - 各要素についての詳細なメッセージ表示

### 技術的な改善

- 日付入力のバリデーション
- 干支と星座の判定ロジック
- レスポンシブデザインの対応

### テスト方法

1. index.htmlをブラウザで開く
2. 二人分の名前と生年月日を入力
3. 「占う！」ボタンをクリック
4. 結果の表示を確認
   - 総合相性
   - 名前の相性
   - 干支の相性
   - 星座の相性
   - 各種メッセージ

### 動作確認済み環境
- Google Chrome最新版
- Firefox最新版
- Safari最新版
- Microsoft Edge最新版

fixes #1